### PR TITLE
Fix broken ipython doc links.

### DIFF
--- a/_sources/core/ipython.txt
+++ b/_sources/core/ipython.txt
@@ -127,11 +127,11 @@ Try::
 Further resources
 ^^^^^^^^^^^^^^^^^^
 
-- `IPython docs page <http://ipython.github.com/ipython-doc/stable/html/index.html>`_
+- `IPython docs page <https://jupyter.readthedocs.org/en/latest/>`_
 - `IPython customization
-  <http://ipython.scipy.org/doc/rel-0.9.1/html/config/customization.html>`_ :
+  <https://ipython.org/ipython-doc/rel-0.9.1/html/config/index.html>`_ :
   E.g. to always import certain modules read `The ipythonrc approach
-  <http://ipython.scipy.org/doc/rel-0.9.1/html/config/customization.html#the-ipythonrc-approach>`_
+  <https://ipython.org/ipython-doc/rel-0.9.1/html/config/customization.html#the-ipythonrc-approach>`_
   which explains editing ``~/.ipython/ipythonrc`` and setting the
   ``import_mod`` configuration.
 


### PR DESCRIPTION
The ipython docs seem to no longer be available as scipy.org,
so switch the the equivalent link at ipython.org.

Things are further confused by the unification of the various
ipython backends under project jupyter. I moved the general
documentation link there, but the name change will be confusing.

Probably the whole section should be updated for the name change.